### PR TITLE
DR feedback + fixes

### DIFF
--- a/connect/reports/datamodels.py
+++ b/connect/reports/datamodels.py
@@ -2,6 +2,7 @@
 
 import os
 from dataclasses import asdict, dataclass, field
+from functools import cached_property
 from typing import Any, Dict, List
 
 
@@ -25,6 +26,7 @@ class RendererDefinition:
     id: str
     type: str
     description: str
+    default: bool = False
     template: str = field(default=None)
     args: Dict[str, Any] = field(default=None)
 
@@ -51,9 +53,14 @@ class ReportDefinition:
     entrypoint: str
     audience: List[str]
     report_spec: str
-    default_renderer: str
     renderers: List[RendererDefinition]
     parameters: List[ParameterDefinition] = field(default_factory=list)
+
+    @cached_property
+    def default_renderer(self):
+        for renderer in self.renderers:
+            if renderer.default:
+                return renderer.id
 
     @property
     def local_id(self):

--- a/connect/reports/parser.py
+++ b/connect/reports/parser.py
@@ -29,6 +29,7 @@ def parse(root_path, data):
                     id=default_renderer,
                     type='xlsx',
                     description='Render report to Excel.',
+                    default=True,
                     template=template,
                     args={
                         'start_row': start_row,
@@ -36,7 +37,6 @@ def parse(root_path, data):
                     }),
             ]
         if report['report_spec'] == '2':
-            default_renderer = report.pop('default_renderer')
             renderers_definitions = [
                 RendererDefinition(root_path=root_path, **renderer)
                 for renderer in report.pop('renderers')
@@ -45,7 +45,6 @@ def parse(root_path, data):
         reports_definitions.append(
             ReportDefinition(
                 root_path=root_path,
-                default_renderer=default_renderer,
                 parameters=parameters_definitions,
                 renderers=renderers_definitions,
                 **report,

--- a/connect/reports/renderers/base.py
+++ b/connect/reports/renderers/base.py
@@ -60,15 +60,11 @@ class BaseRenderer(metaclass=ABCMeta):
                 'report_id': self.report.id,
                 'report_name': self.report.name,
                 'runtime_environment': self.environment,
-                'report_execution_parameters': json.dumps(
-                    self.report.values,
-                    indent=4,
-                    sort_keys=True,
-                ),
+                'report_execution_parameters': self.report.values,
             },
         }
         output_file = f'{output_file}.json'
-        json.dump(data, open(output_file, 'w'))
+        json.dump(data, open(output_file, 'w'), indent=4, sort_keys=True)
         return output_file
 
     def pack_files(self, report_file, summary_file, output_file):

--- a/connect/reports/renderers/pdf.py
+++ b/connect/reports/renderers/pdf.py
@@ -7,26 +7,24 @@ from functools import partial
 
 import pytz
 
-from weasyprint import HTML, default_url_fetcher
+from weasyprint import CSS, HTML, default_url_fetcher
 
 from connect.reports.renderers.j2 import Jinja2Renderer
 from connect.reports.renderers.registry import register
 
 
 def local_fetcher(url, root_dir=None, template_dir=None, cwd=None):
-    base_path = os.path.join(
-        os.path.abspath(root_dir),
-        template_dir,
-    )
-    if url.startswith('file://') and not url.startswith(f'file://{base_path}'):
+    if url.startswith(f'file://{cwd}'):
         rel_path = os.path.relpath(url[7:], cwd)
         new_path = os.path.join(
             os.path.abspath(root_dir),
-            template_dir,
             rel_path,
         )
-        new_url = f'file://{new_path}'
-        return default_url_fetcher(new_url)
+        url = f'file://{new_path}'
+    elif url.startswith(f'file://{os.path.abspath(os.path.join(root_dir, template_dir))}'):
+        count = url.count(template_dir)
+        if url.count(template_dir) > 1:
+            url = url.replace(f'{template_dir}/', '', count - 1)
     return default_url_fetcher(url)
 
 
@@ -53,8 +51,13 @@ class PDFRenderer(Jinja2Renderer):
             template_dir=os.path.dirname(self.template),
             cwd=getattr(self, 'cwd', os.getcwd()),
         )
+        kwargs = {}
+        css_file = self.args.get('css_file')
+        if css_file:
+            css = CSS(filename=os.path.join(self.root_dir, css_file), url_fetcher=fetcher)
+            kwargs['stylesheets'] = [css]
         html = HTML(filename=rendered_file, url_fetcher=fetcher)
-        html.write_pdf(output_file)
+        html.write_pdf(output_file, **kwargs)
         return output_file
 
     @classmethod

--- a/connect/reports/renderers/xlsx.py
+++ b/connect/reports/renderers/xlsx.py
@@ -62,9 +62,9 @@ class XLSXRenderer(BaseRenderer):
                 vertical='top',
             )
         ws['A2'].value = 'Report Start time'
-        ws['B2'].value = start_time.isoformat()
+        ws['B2'].value = start_time.strftime('%Y-%m-%d %H:%M:%S')
         ws['A3'].value = 'Report Finish time'
-        ws['B3'].value = datetime.now(tz=pytz.utc).isoformat()
+        ws['B3'].value = datetime.now(tz=pytz.utc).strftime('%Y-%m-%d %H:%M:%S')
         ws['A4'].value = 'Account ID'
         ws['B4'].value = self.account.id
         ws['A5'].value = 'Account Name'

--- a/connect/reports/schemas/reports_schema.json
+++ b/connect/reports/schemas/reports_schema.json
@@ -97,7 +97,7 @@
                         "properties": { "report_spec": { "enum": [ "2" ] } }
                     },
                     "then": {
-                        "required": [ "renderers", "default_renderer" ],
+                        "required": [ "renderers" ],
                         "properties": {
                             "renderers": {
                                 "description": "List of available renderers.",
@@ -106,10 +106,6 @@
                                     "$ref": "#/definitions/renderer"
                                 },
                                 "minItems": 1
-                            },
-                            "default_renderer": {
-                                "description": "Default renderer to use.",
-                                "type": "string"
                             }
                         }
                     }
@@ -135,6 +131,10 @@
                 "template": {
                     "description": "Renderer template file.",
                     "type": "string"
+                },
+                "default": {
+                    "description": "Mark this renderer as default.",
+                    "type": "boolean"
                 },
                 "args": {
                     "description": "Renderer extra keyword arguments.",

--- a/connect/reports/validator.py
+++ b/connect/reports/validator.py
@@ -103,7 +103,10 @@ def _validate_report(report):
         )
 
     renderers_ids = []
+    default_renderers = []
     for renderer in report.renderers:
+        if renderer.default:
+            default_renderers.append(renderer.id)
         renderers_ids.append(renderer.id)
         errors.extend(_validate_renderer(report, renderer))
 
@@ -111,11 +114,12 @@ def _validate_report(report):
     if diff:
         errors.append(f'report {report.local_id} has duplicated renderer ids: {",".join(diff)}')
 
-    if report.default_renderer not in renderers_ids:
+    if len(default_renderers) > 1:
         errors.append(
-            f'default renderer for report {report.local_id} '
-            f'does not exist: {report.default_renderer}',
+            f'report {report.local_id} has multiple default renderers: '
+            f'{",".join(default_renderers)}',
         )
+
     return errors
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,13 +31,16 @@ def param_json():
 def renderer_json():
     def _renderer_data(
         id='renderer_id', type='xlsx',
-        description='XLSX renderer', template=None,
+        description='XLSX renderer',
+        default=True,
+        template=None,
         args=None,
     ):
         data = {
             'id': id,
             'type': type,
             'description': description,
+            'default': default,
         }
         if template is not None:
             data['template'] = template
@@ -59,7 +62,6 @@ def report_v2_json(param_json, renderer_json):
         audience=['vendor', 'provider'],  # noqa: B006
         parameters=[param_json()],  # noqa: B006
         renderers=[renderer_json()],  # noqa: B006
-        default_renderer='renderer_id',
     ):
 
         data = {
@@ -70,7 +72,6 @@ def report_v2_json(param_json, renderer_json):
             'parameters': parameters,
             'renderers': renderers,
             'report_spec': '2',
-            'default_renderer': default_renderer,
         }
 
         return data

--- a/tests/reports/test_datamodels.py
+++ b/tests/reports/test_datamodels.py
@@ -8,6 +8,7 @@ from fs.tempfs import TempFS
 
 from connect.reports.datamodels import (
     ParameterDefinition,
+    RendererDefinition,
     ReportDefinition,
     RepositoryDefinition,
 )
@@ -39,6 +40,14 @@ def test_report_definition_description(mocker, report_v2_json):
     defs = ReportDefinition(root_path='root_path', **report_json)
     assert defs.description == expected_descr
     assert mocked_open.mock_calls[0].args == (expected_readme_path, 'r')
+
+
+def test_report_definition_default_renderer(mocker, report_v2_json, renderer_json):
+    report_json = report_v2_json(
+        renderers=[RendererDefinition(root_path='root_path', **renderer_json())],
+    )
+    defs = ReportDefinition(root_path='root_path', **report_json)
+    assert defs.default_renderer == defs.renderers[0].id
 
 
 def test_report_get_parameters(mocker, report_v2_json, param_json):

--- a/tests/reports/test_schema.py
+++ b/tests/reports/test_schema.py
@@ -177,7 +177,7 @@ def test_reportv1_object_report_spec(repo_json, report_v1_json):
     ('field'),
     (
         'name', 'readme_file', 'entrypoint', 'audience',
-        'report_spec', 'renderers', 'default_renderer',
+        'report_spec', 'renderers',
     ),
 )
 def test_reportv2_object_required_fields(repo_json, report_v2_json, field):
@@ -192,7 +192,7 @@ def test_reportv2_object_required_fields(repo_json, report_v2_json, field):
 
 @pytest.mark.parametrize(
     ('field'),
-    ('name', 'readme_file', 'entrypoint', 'report_spec', 'default_renderer'),
+    ('name', 'readme_file', 'entrypoint', 'report_spec'),
 )
 def test_reportv2_object_string_fields(repo_json, report_v2_json, field):
     report = report_v2_json()

--- a/tests/reports/test_validator.py
+++ b/tests/reports/test_validator.py
@@ -63,6 +63,7 @@ def test_validator_renderer_unknown_type(param_json, renderer_type):
         'root_path': tmp_fs.root_path,
         'id': '123',
         'type': renderer_type,
+        'default': True,
         'description': 'Renderer',
     }
     renderer = RendererDefinition(**renderer_dict)
@@ -70,7 +71,6 @@ def test_validator_renderer_unknown_type(param_json, renderer_type):
         root_path=tmp_fs.root_path,
         **report_dict,
         renderers=[renderer],
-        default_renderer=renderer.id,
     )
 
     errors = _validate_renderer(report, renderer)
@@ -87,9 +87,10 @@ def test_validator_readme_file_not_existing(report_v2_json):
         'id': '321',
         'type': 'json',
         'description': 'JSON Renderer',
+        'default': True,
     }
     renderer = RendererDefinition(**renderer_json_dict)
-    report_dict = report_v2_json(renderers=[renderer], default_renderer=renderer.id)
+    report_dict = report_v2_json(renderers=[renderer])
     report = ReportDefinition(
         root_path='root_path',
         **report_dict,
@@ -114,7 +115,6 @@ def test_validator_entrypoint_bad_format(report_v2_json):
         readme_file='readme.md',
         entrypoint='mypackage',
         renderers=[renderer],
-        default_renderer=str(renderer),
     )
     report = ReportDefinition(
         root_path=tmp_filesystem.root_path,
@@ -134,12 +134,12 @@ def test_validator_entrypoint_bad_directory_structure(report_v2_json):
         'id': '321',
         'type': 'json',
         'description': 'JSON Renderer',
+        'default': True,
     }
     renderer = RendererDefinition(**renderer_json_dict)
     report_dict = report_v2_json(
         readme_file='readme.md',
         renderers=[renderer],
-        default_renderer=str(renderer),
     )
     report = ReportDefinition(
         root_path=tmp_filesystem.root_path,
@@ -168,13 +168,13 @@ def test_validator_duplicate_renderers_error(param_json):
         'id': '123',
         'type': 'csv',
         'description': 'CSV Renderer',
+        'default': True,
     }
     renderer = RendererDefinition(**renderer_dict)
     report = ReportDefinition(
         root_path=tmp_fs.root_path,
         **report_dict,
         renderers=[renderer, renderer],
-        default_renderer=str(renderer),
     )
     errors = _validate_report(report)
 
@@ -199,19 +199,19 @@ def test_validator_ok(param_json):
         'id': '123',
         'type': 'csv',
         'description': 'CSV Renderer',
+        'default': True,
     }
     csv_renderer = RendererDefinition(**renderer_csv_dict)
     report = ReportDefinition(
         root_path=tmp_fs.root_path,
         **report_dict,
         renderers=[csv_renderer],
-        default_renderer=csv_renderer.id,
     )
     errors = _validate_report(report)
     assert len(errors) == 0
 
 
-def test_validator_wrong_default_renderer(param_json):
+def test_validator_multiple_default_renderer(param_json):
     report_dict = {
         'name': 'Report',
         'readme_file': 'readme.md',
@@ -228,24 +228,25 @@ def test_validator_wrong_default_renderer(param_json):
         'id': '321',
         'type': 'json',
         'description': 'JSON Renderer',
+        'default': True,
     }
     renderer_csv_dict = {
         'root_path': tmp_fs.root_path,
         'id': '123',
         'type': 'csv',
         'description': 'CSV Renderer',
+        'default': True,
     }
     csv_renderer = RendererDefinition(**renderer_csv_dict)
     json_renderer = RendererDefinition(**renderer_json_dict)
     report = ReportDefinition(
         root_path=tmp_fs.root_path,
         **report_dict,
-        renderers=[csv_renderer],
-        default_renderer=json_renderer.id,
+        renderers=[csv_renderer, json_renderer],
     )
     errors = _validate_report(report)
     assert len(errors) != 0
-    assert f'does not exist: {report.default_renderer}' in errors[0]
+    assert f'report {report.local_id} has multiple default renderers:' in errors[0]
 
 
 def test_validator_repo_readme_file_missing(param_json):
@@ -262,13 +263,13 @@ def test_validator_repo_readme_file_missing(param_json):
         'id': '123',
         'type': 'csv',
         'description': 'CSV Renderer',
+        'default': True,
     }
     csv_renderer = RendererDefinition(**renderer_csv_dict)
     report = ReportDefinition(
         root_path='root_path',
         **report_dict,
         renderers=[csv_renderer],
-        default_renderer=csv_renderer.id,
     )
     repo_dict = {
         'name': 'Reports Repository',
@@ -310,19 +311,18 @@ def test_validator_repo_duplicated_reports(mocker, param_json):
         'id': '123',
         'type': 'csv',
         'description': 'CSV Renderer',
+        'default': True,
     }
     csv_renderer = RendererDefinition(**renderer_csv_dict)
     report_1 = ReportDefinition(
         root_path='root_path',
         **report_dict_1,
         renderers=[csv_renderer],
-        default_renderer=csv_renderer.id,
     )
     report_2 = ReportDefinition(
         root_path='root_path',
         **report_dict_2,
         renderers=[csv_renderer],
-        default_renderer=csv_renderer.id,
     )
     tmp_filesystem = TempFS()
     tmp_filesystem.create('readme.md')


### PR DESCRIPTION
Improvement: Change the way to mark a renderer as default renderer (now a boolean attribute of the renderer

Fix: fetcher, now for pdf templates, paths must be all relative to reports project root folder (both html and css)
Fix: pdf renderer does not take external css into account
Fix: Coversheet for xlsx use wrong datetime format