### PR TITLE
LITE-19949: added style capability for xlsx render

### DIFF
--- a/connect/reports/renderers/xlsx.py
+++ b/connect/reports/renderers/xlsx.py
@@ -29,6 +29,15 @@ class XLSXRenderer(BaseRenderer):
         self.start_time = start_time or datetime.now(tz=pytz.utc)
         return self.generate_report(data, output_file)
 
+    def get_cell_content(self, data):
+        """
+        Generates the content of the cell. It accepts a collection between 1 and 2 elements. If
+         it is 1, it is just the data, if it is 2, the second element contains the cell named style.
+        """
+        if type(data) in (tuple, dict, list) and len(data) == 2 and data[1]:
+            return {'value': data[0], 'style': data[1]}
+        return {'value': data}
+
     def generate_report(self, data, output_file):
         start_col_idx = self.args.get('start_col', 1)
         row_idx = self.args.get('start_row', 2)
@@ -41,7 +50,8 @@ class XLSXRenderer(BaseRenderer):
         ws = wb['Data']
         for row in data:
             for col_idx, cell_value in enumerate(row, start=start_col_idx):
-                ws.cell(row_idx, col_idx, value=cell_value)
+                content = self.get_cell_content(cell_value)
+                ws.cell(row_idx, col_idx, **content)
             row_idx += 1
 
         self._add_info_sheet(wb.create_sheet('Info'), self.start_time)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,9 @@
 
 import pytest
 
+from openpyxl.styles import Alignment, Font, NamedStyle
+from openpyxl.styles.colors import BLUE
+
 from connect.reports.datamodels import Account, Report
 
 
@@ -162,6 +165,29 @@ def report_data():
             [f'row_{i}_col_{j}' for j in range(cols)]
             for i in range(rows)
         ]
+    return _data
+
+
+TEST_STYLE = NamedStyle(
+    name="header",
+    font=Font(bold=True, color=BLUE),
+    alignment=Alignment(horizontal="center", vertical="center"),
+)
+
+
+@pytest.fixture
+def report_data_with_styles():
+    def _data(rows=10, cols=10, style_cells=None):
+        content = []
+        for i in range(rows):
+            row = []
+            for j in range(cols):
+                if not style_cells or (i, j) in style_cells:
+                    row.append((f'row_{i}_col_{j}', TEST_STYLE))
+                else:
+                    row.append(f'row_{i}_col_{j}')
+            content.append(row)
+        return content
     return _data
 
 

--- a/tests/reports/renderers/test_xlsx.py
+++ b/tests/reports/renderers/test_xlsx.py
@@ -11,6 +11,8 @@ from openpyxl import Workbook, load_workbook
 from connect.reports.datamodels import RendererDefinition
 from connect.reports.renderers import XLSXRenderer
 
+from tests.conftest import TEST_STYLE
+
 
 @pytest.mark.parametrize('args', (None, {}, {'start_row': 1, 'start_col': 1}))
 def test_validate_ok(mocker, args):
@@ -85,6 +87,54 @@ def test_generate_report(mocker, account_factory, report_factory, report_data):
     for i in range(10):
         for j in range(10):
             expected_calls.append(mocker.call(2 + i, 1 + j, value=f'row_{i}_col_{j}'))
+
+    data_sheet = mocker.MagicMock()
+
+    wbmock = mocker.MagicMock()
+    wbmock.__getitem__.side_effect = [data_sheet]
+
+    mocked_load_wb = mocker.patch(
+        'connect.reports.renderers.xlsx.load_workbook',
+        return_value=wbmock,
+    )
+    acc = account_factory()
+    report = report_factory()
+
+    renderer = XLSXRenderer(
+        'runtime environment', 'root_path', acc, report, template='template.xlsx',
+    )
+
+    renderer.generate_summary = mocker.MagicMock()
+    renderer.start_time = datetime.utcnow()
+
+    assert renderer.generate_report(data, 'report') == 'report.xlsx'
+    mocked_load_wb.assert_called_once_with('root_path/template.xlsx')
+    data_sheet.cell.assert_has_calls(expected_calls)
+    wbmock.save.assert_called_once_with('report.xlsx')
+
+
+def test_generate_report_with_style(
+    mocker,
+    account_factory,
+    report_factory,
+    report_data_with_styles,
+):
+    style_cells = [(2, 2), (2, 5), (4, 4), (6, 6), (7, 7)]
+    data = report_data_with_styles(style_cells=style_cells)
+
+    expected_calls = []
+    for i in range(10):
+        for j in range(10):
+            kwargs = {'value': f'row_{i}_col_{j}'}
+            if (i, j) in style_cells:
+                kwargs['style'] = TEST_STYLE
+            expected_calls.append(
+                mocker.call(
+                    2 + i,
+                    1 + j,
+                    **kwargs,
+                ),
+            )
 
     data_sheet = mocker.MagicMock()
 


### PR DESCRIPTION
This PR is adding the capability to use styles in the xlsx render. Now you could send from the entrypoint function either a value (string) or a tuple containing value (string) and style (openpyxl NamedStyle). Each cell will be independent so you could specify style to whatever cell you want.